### PR TITLE
New persistence policy

### DIFF
--- a/src/main/java/rcms/utilities/daqaggregator/DAQAggregator.java
+++ b/src/main/java/rcms/utilities/daqaggregator/DAQAggregator.java
@@ -88,13 +88,14 @@ public class DAQAggregator {
 			MappingManager mappingManager = null;
 			DAQ daq = null;
 			Set<String> flashlistUrls = new HashSet<String>(Arrays.asList(lasURLs));
-			
+
 			String persistenceDir = daqAggregatorProperties.getProperty(PERSISTENCE_DIR);
-			if(persistenceDir == null){
+			if (persistenceDir == null) {
 				persistenceDir = "/tmp/snapshots/";
 			}
-			
+
 			PersistorManager persistorManager = new PersistorManager(persistenceDir);
+
 			FlashlistManager flashlistManager = null;
 
 			while (true) {
@@ -129,6 +130,7 @@ public class DAQAggregator {
 					} else {
 						logger.warn("Flashlist manager not initialized, session id not available");
 					}
+
 					// FIXME: the timer should be used here as sleep time !=
 					// period time
 					logger.info("sleeping for 2 seconds ....\n");

--- a/src/main/java/rcms/utilities/daqaggregator/DAQAggregator.java
+++ b/src/main/java/rcms/utilities/daqaggregator/DAQAggregator.java
@@ -124,15 +124,17 @@ public class DAQAggregator {
 						logger.info("Done for session " + daq.getSessionId());
 					}
 
-					prepareAndPersistSnapshot(daq, flashlistManager, persistorManager);
-
+					if (flashlistManager != null) {
+						prepareAndPersistSnapshot(daq, flashlistManager, persistorManager);
+					} else {
+						logger.warn("Flashlist manager not initialized, session id not available");
+					}
 					// FIXME: the timer should be used here as sleep time !=
 					// period time
 					logger.info("sleeping for 2 seconds ....\n");
 					Thread.sleep(2000);
 				} catch (Exception e) {
-					logger.error("Error in main loop:\n" + e);
-					e.printStackTrace();
+					logger.error("Error in main loop:", e);
 					logger.info("Going to sleep for 10 seconds before trying again...\n");
 					Thread.sleep(10000);
 				}

--- a/src/main/java/rcms/utilities/daqaggregator/data/BU.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/BU.java
@@ -2,8 +2,6 @@ package rcms.utilities.daqaggregator.data;
 
 import java.util.Comparator;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import rcms.utilities.daqaggregator.mappers.FlashlistType;
@@ -16,7 +14,6 @@ import rcms.utilities.daqaggregator.mappers.FlashlistUpdatable;
  * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
  *
  */
-@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
 public class BU implements FlashlistUpdatable {
 
 	// ----------------------------------------

--- a/src/main/java/rcms/utilities/daqaggregator/data/BUSummary.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/BUSummary.java
@@ -1,8 +1,5 @@
 package rcms.utilities.daqaggregator.data;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-
 import rcms.utilities.daqaggregator.mappers.Derivable;
 
 /**
@@ -12,8 +9,8 @@ import rcms.utilities.daqaggregator.mappers.Derivable;
  * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
  */
 
-@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
-public class BUSummary implements Derivable{
+
+public class BUSummary implements Derivable {
 
 	// ----------------------------------------
 	// fields set at beginning of session
@@ -21,6 +18,8 @@ public class BUSummary implements Derivable{
 
 	/** parent */
 	private DAQ daq;
+
+	private final String id = "busummary";
 
 	// ----------------------------------------
 	// fields updated periodically
@@ -370,6 +369,10 @@ public class BUSummary implements Derivable{
 
 	public void setFuOutputBandwidthInMB(double fuOutputBandwidthInMB) {
 		this.fuOutputBandwidthInMB = fuOutputBandwidthInMB;
+	}
+
+	public String getId() {
+		return id;
 	}
 
 }

--- a/src/main/java/rcms/utilities/daqaggregator/data/DAQ.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/DAQ.java
@@ -1,12 +1,8 @@
 package rcms.utilities.daqaggregator.data;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import rcms.utilities.daqaggregator.mappers.FlashlistType;
@@ -19,42 +15,20 @@ import rcms.utilities.daqaggregator.mappers.FlashlistUpdatable;
  * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
  * 
  */
-@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
-@JsonPropertyOrder({ "allFeds", "frlPcs", "subSystems", "fedBuilders", "fmmApplications" })
 public class DAQ implements FlashlistUpdatable {
 
-
+	private final String id = "daq";
 	// ----------------------------------------
 	// fields set at beginning of session
 	// ----------------------------------------
-	private Set<SubSystem> subSystems;
-
-	private List<FRLPc> frlPcs;
-
-	private List<BU> bus;
-
-	private List<FMMApplication> fmmApplications;
 
 	private int sessionId;
 
 	private String dpsetPath;
 
-	private FEDBuilderSummary fedBuilderSummary;
-
-	private BUSummary buSummary;
-
-	private Set<FED> allFeds;
-
-	// TODO: fed builders not in the structure, but addes tmprlly?
-	private final List<FEDBuilder> fedBuilders = new ArrayList<>();
-
 	// ----------------------------------------
 	// fields updated periodically
 	// ----------------------------------------
-
-	public List<FEDBuilder> getFedBuilders() {
-		return fedBuilders;
-	}
 
 	private int runNumber;
 
@@ -66,6 +40,124 @@ public class DAQ implements FlashlistUpdatable {
 	private String levelZeroState;
 	private String lhcMachineMode;
 	private String lhcBeamMode;
+
+	private BUSummary buSummary;
+	private FEDBuilderSummary fedBuilderSummary;
+	private List<SubSystem> subSystems;
+	private List<TTCPartition> ttcPartitions;
+	private List<BU> bus;
+	private List<RU> rus;
+	private List<FEDBuilder> fedBuilders;
+	private List<FMMApplication> fmmApplications;
+	private List<FMM> fmms;
+	private List<FRLPc> frlPcs;
+	private List<FRL> frls;
+	private List<SubFEDBuilder> subFEDBuilders;
+	private Collection<FED> feds;
+
+	public BUSummary getBuSummary() {
+		return buSummary;
+	}
+
+	public void setBuSummary(BUSummary buSummary) {
+		this.buSummary = buSummary;
+	}
+
+	public FEDBuilderSummary getFedBuilderSummary() {
+		return fedBuilderSummary;
+	}
+
+	public void setFedBuilderSummary(FEDBuilderSummary fedBuilderSummary) {
+		this.fedBuilderSummary = fedBuilderSummary;
+	}
+
+	public List<SubSystem> getSubSystems() {
+		return subSystems;
+	}
+
+	public void setSubSystems(List<SubSystem> subSystems) {
+		this.subSystems = subSystems;
+	}
+
+	public List<TTCPartition> getTtcPartitions() {
+		return ttcPartitions;
+	}
+
+	public void setTtcPartitions(List<TTCPartition> ttcPartitions) {
+		this.ttcPartitions = ttcPartitions;
+	}
+
+	public List<BU> getBus() {
+		return bus;
+	}
+
+	public void setBus(List<BU> bus) {
+		this.bus = bus;
+	}
+
+	public List<RU> getRus() {
+		return rus;
+	}
+
+	public void setRus(List<RU> rus) {
+		this.rus = rus;
+	}
+
+	public List<FEDBuilder> getFedBuilders() {
+		return fedBuilders;
+	}
+
+	public void setFedBuilders(List<FEDBuilder> fedBuilders) {
+		this.fedBuilders = fedBuilders;
+	}
+
+	public List<FMMApplication> getFmmApplications() {
+		return fmmApplications;
+	}
+
+	public void setFmmApplications(List<FMMApplication> fmmApplications) {
+		this.fmmApplications = fmmApplications;
+	}
+
+	public List<FMM> getFmms() {
+		return fmms;
+	}
+
+	public void setFmms(List<FMM> fmms) {
+		this.fmms = fmms;
+	}
+
+	public List<FRLPc> getFrlPcs() {
+		return frlPcs;
+	}
+
+	public void setFrlPcs(List<FRLPc> frlPcs) {
+		this.frlPcs = frlPcs;
+	}
+
+	public List<FRL> getFrls() {
+		return frls;
+	}
+
+	public void setFrls(List<FRL> frls) {
+		this.frls = frls;
+	}
+
+	public List<SubFEDBuilder> getSubFEDBuilders() {
+		return subFEDBuilders;
+	}
+
+	public void setSubFEDBuilders(List<SubFEDBuilder> subFEDBuilders) {
+		this.subFEDBuilders = subFEDBuilders;
+	}
+
+	public Collection<FED> getFeds() {
+		return feds;
+	}
+
+	public void setFeds(Collection<FED> feds) {
+		this.feds = feds;
+	}
 
 	public int getRunNumber() {
 		return runNumber;
@@ -91,18 +183,6 @@ public class DAQ implements FlashlistUpdatable {
 		this.daqState = daqState;
 	}
 
-	public List<FRLPc> getFrlPcs() {
-		return frlPcs;
-	}
-
-	public List<BU> getBus() {
-		return bus;
-	}
-
-	public List<FMMApplication> getFmmApplications() {
-		return fmmApplications;
-	}
-
 	public int getSessionId() {
 		return sessionId;
 	}
@@ -111,40 +191,12 @@ public class DAQ implements FlashlistUpdatable {
 		return dpsetPath;
 	}
 
-	public FEDBuilderSummary getFedBuilderSummary() {
-		return fedBuilderSummary;
-	}
-
-	public BUSummary getBuSummary() {
-		return buSummary;
-	}
-
-	public void setFrlPcs(List<FRLPc> frlPcs) {
-		this.frlPcs = frlPcs;
-	}
-
-	public void setBus(List<BU> bus) {
-		this.bus = bus;
-	}
-
-	public void setFmmApplications(List<FMMApplication> fmmApplications) {
-		this.fmmApplications = fmmApplications;
-	}
-
 	public void setSessionId(int sessionId) {
 		this.sessionId = sessionId;
 	}
 
 	public void setDpsetPath(String dpsetPath) {
 		this.dpsetPath = dpsetPath;
-	}
-
-	public void setFedBuilderSummary(FEDBuilderSummary fedBuilderSummary) {
-		this.fedBuilderSummary = fedBuilderSummary;
-	}
-
-	public void setBuSummary(BUSummary buSummary) {
-		this.buSummary = buSummary;
 	}
 
 	@Override
@@ -183,32 +235,15 @@ public class DAQ implements FlashlistUpdatable {
 		this.lhcBeamMode = lhcBeamMode;
 	}
 
-	public Set<SubSystem> getSubSystems() {
-		return subSystems;
-	}
-
-	public void setSubSystems(Set<SubSystem> subSystems) {
-		this.subSystems = subSystems;
-	}
-
 	@Override
 	public void clean() {
 		// nothing to do
-	}
-
-	public Set<FED> getAllFeds() {
-		return allFeds;
-	}
-
-	public void setAllFeds(Set<FED> allFeds) {
-		this.allFeds = allFeds;
 	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((allFeds == null) ? 0 : allFeds.hashCode());
 		result = prime * result + ((buSummary == null) ? 0 : buSummary.hashCode());
 		result = prime * result + ((bus == null) ? 0 : bus.hashCode());
 		result = prime * result + ((daqState == null) ? 0 : daqState.hashCode());
@@ -236,11 +271,6 @@ public class DAQ implements FlashlistUpdatable {
 		if (getClass() != obj.getClass())
 			return false;
 		DAQ other = (DAQ) obj;
-		if (allFeds == null) {
-			if (other.allFeds != null)
-				return false;
-		} else if (!allFeds.equals(other.allFeds))
-			return false;
 		if (buSummary == null) {
 			if (other.buSummary != null)
 				return false;
@@ -308,6 +338,10 @@ public class DAQ implements FlashlistUpdatable {
 		} else if (!subSystems.equals(other.subSystems))
 			return false;
 		return true;
+	}
+
+	public String getId() {
+		return id;
 	}
 
 }

--- a/src/main/java/rcms/utilities/daqaggregator/data/FED.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/FED.java
@@ -3,10 +3,7 @@ package rcms.utilities.daqaggregator.data;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import rcms.utilities.daqaggregator.mappers.FlashlistType;
@@ -18,7 +15,6 @@ import rcms.utilities.daqaggregator.mappers.FlashlistUpdatable;
  * @author Andre Georg Holzner (andre.georg.holzner@cern.ch)
  * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
  */
-@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
 public class FED implements FlashlistUpdatable {
 
 	// ----------------------------------------
@@ -29,14 +25,11 @@ public class FED implements FlashlistUpdatable {
 	private int id;
 
 	/** the parent FRL */
-	@JsonBackReference(value = "frl-fed")
 	private FRL frl;
 
 	/** can be null */
-	@JsonBackReference(value = "fmm-fed")
 	private FMM fmm;
 
-	@JsonBackReference(value = "ttcp-fed")
 	private TTCPartition ttcp;
 
 	/** which FRL input: 0 or 1 */

--- a/src/main/java/rcms/utilities/daqaggregator/data/FEDBuilder.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/FEDBuilder.java
@@ -3,16 +3,12 @@ package rcms.utilities.daqaggregator.data;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-
 /**
  * Front End Driver Builder
  * 
  * @author Andre Georg Holzner (andre.georg.holzner@cern.ch)
  * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
  */
-@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
 public class FEDBuilder {
 
 	// ----------------------------------------

--- a/src/main/java/rcms/utilities/daqaggregator/data/FEDBuilderSummary.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/FEDBuilderSummary.java
@@ -1,8 +1,5 @@
 package rcms.utilities.daqaggregator.data;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-
 import rcms.utilities.daqaggregator.mappers.Derivable;
 
 /**
@@ -12,12 +9,13 @@ import rcms.utilities.daqaggregator.mappers.Derivable;
  * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
  */
 
-@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
-public class FEDBuilderSummary implements Derivable{
+public class FEDBuilderSummary implements Derivable {
 
 	// ----------------------------------------
 	// fields set at beginning of session
 	// ----------------------------------------
+
+	private final String id = "fedbuildersummary";
 
 	/** parent */
 	private DAQ daq;
@@ -228,5 +226,9 @@ public class FEDBuilderSummary implements Derivable{
 		if (Float.floatToIntBits(throughput) != Float.floatToIntBits(other.throughput))
 			return false;
 		return true;
+	}
+
+	public String getId() {
+		return id;
 	}
 }

--- a/src/main/java/rcms/utilities/daqaggregator/data/FMM.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/FMM.java
@@ -3,11 +3,6 @@ package rcms.utilities.daqaggregator.data;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import rcms.utilities.daqaggregator.mappers.FlashlistType;
@@ -19,8 +14,9 @@ import rcms.utilities.daqaggregator.mappers.FlashlistUpdatable;
  * @author Andre Georg Holzner (andre.georg.holzner@cern.ch)
  * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
  */
-@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
 public class FMM implements FlashlistUpdatable {
+
+	private String id;
 
 	
 	
@@ -29,7 +25,6 @@ public class FMM implements FlashlistUpdatable {
 	// ----------------------------------------
 
 	/** parent TTCPartition */
-	@JsonManagedReference(value = "fmm-ttcp")
 	private TTCPartition ttcPartition;
 
 	private FMMApplication fmmApplication;
@@ -38,15 +33,14 @@ public class FMM implements FlashlistUpdatable {
 	
 	private String serviceName;
 	
+
 	private int geoslot;
 
 	private String url;
 
-	@JsonManagedReference(value = "fmm-fed")
 	private List<FED> feds = new ArrayList<FED>();
 
-	@JsonIgnore
-	public boolean takeB;
+	private boolean takeB;
 
 	public TTCPartition getTtcPartition() {
 		return ttcPartition;
@@ -161,4 +155,21 @@ public class FMM implements FlashlistUpdatable {
 			return false;
 		return true;
 	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+	
+	public boolean isTakeB() {
+		return takeB;
+	}
+
+	public void setTakeB(boolean takeB) {
+		this.takeB = takeB;
+	}
+
 }

--- a/src/main/java/rcms/utilities/daqaggregator/data/FMMApplication.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/FMMApplication.java
@@ -3,8 +3,6 @@ package rcms.utilities.daqaggregator.data;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import rcms.utilities.daqaggregator.mappers.FlashlistType;
@@ -16,7 +14,6 @@ import rcms.utilities.daqaggregator.mappers.FlashlistUpdatable;
  * @author Andre Georg Holzner (andre.georg.holzner@cern.ch)
  * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
  */
-@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
 public class FMMApplication implements FlashlistUpdatable {
 
 	// ----------------------------------------

--- a/src/main/java/rcms/utilities/daqaggregator/data/FRL.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/FRL.java
@@ -3,11 +3,6 @@ package rcms.utilities.daqaggregator.data;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import rcms.utilities.daqaggregator.mappers.FlashlistType;
@@ -19,12 +14,13 @@ import rcms.utilities.daqaggregator.mappers.FlashlistUpdatable;
  * @author Andre Georg Holzner (andre.georg.holzner@cern.ch)
  * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
  */
-@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
 public class FRL implements FlashlistUpdatable {
 
 	// ----------------------------------------
 	// fields set at beginning of session
 	// ----------------------------------------
+	
+	private String id;
 
 	/** the parent SubFEDBuilder this FRL belongs to */
 	private SubFEDBuilder subFedbuilder;
@@ -38,12 +34,8 @@ public class FRL implements FlashlistUpdatable {
 	 * maps from 0, 1 to FED. Note that some FRLs have only FED 1 connected but
 	 * not FED 0
 	 */
-	@JsonManagedReference(value = "frl-fed")
 	private final Map<Integer, FED> feds = new HashMap<>();
 
-
-	@JsonIgnore
-	@JsonManagedReference(value = "frl-frlpc")
 	private FRLPc frlPc;
 
 	// ----------------------------------------
@@ -137,7 +129,7 @@ public class FRL implements FlashlistUpdatable {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + ((feds == null) ? 0 : feds.hashCode());
-		//result = prime * result + ((frlPc == null) ? 0 : frlPc.hashCode());
+		// result = prime * result + ((frlPc == null) ? 0 : frlPc.hashCode());
 		result = prime * result + geoSlot;
 		result = prime * result + ((state == null) ? 0 : state.hashCode());
 		result = prime * result + ((substate == null) ? 0 : substate.hashCode());
@@ -160,11 +152,11 @@ public class FRL implements FlashlistUpdatable {
 				return false;
 		} else if (!feds.equals(other.feds))
 			return false;
-//		if (frlPc == null) {
-//			if (other.frlPc != null)
-//				return false;
-//		} else if (!frlPc.equals(other.frlPc))
-//			return false;
+		// if (frlPc == null) {
+		// if (other.frlPc != null)
+		// return false;
+		// } else if (!frlPc.equals(other.frlPc))
+		// return false;
 		if (geoSlot != other.geoSlot)
 			return false;
 		if (state == null) {
@@ -185,6 +177,14 @@ public class FRL implements FlashlistUpdatable {
 		} else if (!url.equals(other.url))
 			return false;
 		return true;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
 	}
 
 	// ----------------------------------------------------------------------

--- a/src/main/java/rcms/utilities/daqaggregator/data/FRLPc.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/FRLPc.java
@@ -3,10 +3,6 @@ package rcms.utilities.daqaggregator.data;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import rcms.utilities.daqaggregator.mappers.Derivable;
@@ -20,7 +16,6 @@ import rcms.utilities.daqaggregator.mappers.FlashlistUpdatable;
  * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
  */
 
-@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
 public class FRLPc implements FlashlistUpdatable, Derivable {
 
 	// ----------------------------------------
@@ -31,8 +26,6 @@ public class FRLPc implements FlashlistUpdatable, Derivable {
 
 	private boolean masked;
 
-	@JsonIgnore
-	@JsonBackReference(value = "frl-frlpc")
 	private List<FRL> frls = new ArrayList<>();
 
 	// ----------------------------------------

--- a/src/main/java/rcms/utilities/daqaggregator/data/RU.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/RU.java
@@ -1,14 +1,11 @@
 package rcms.utilities.daqaggregator.data;
 
-import java.io.Serializable;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.JsonNode;
 
-import rcms.utilities.daqaggregator.mappers.FlashlistUpdatable;
 import rcms.utilities.daqaggregator.mappers.Derivable;
 import rcms.utilities.daqaggregator.mappers.FlashlistType;
+import rcms.utilities.daqaggregator.mappers.FlashlistUpdatable;
 
 /**
  * Readout Unit
@@ -17,8 +14,7 @@ import rcms.utilities.daqaggregator.mappers.FlashlistType;
  * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
  */
 
-@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
-public class RU implements Serializable, FlashlistUpdatable, Derivable {
+public class RU implements FlashlistUpdatable, Derivable {
 
 	// ----------------------------------------
 	// fields set at beginning of session

--- a/src/main/java/rcms/utilities/daqaggregator/data/SubFEDBuilder.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/SubFEDBuilder.java
@@ -3,9 +3,6 @@ package rcms.utilities.daqaggregator.data;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-
 /**
  * 
  * Class representing one line in DAQView
@@ -14,9 +11,10 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
  * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
  * 
  */
-@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
 public class SubFEDBuilder {
 
+	private String id;
+	
 	// ----------------------------------------
 	// fields set at beginning of session
 	// ----------------------------------------
@@ -146,6 +144,14 @@ public class SubFEDBuilder {
 	public String toString() {
 		return "SubFEDBuilder [ttcPartition=" + ttcPartition + ", frlPc=" + frlPc
 				+ ", frls=" + frls + ", minTrig=" + minTrig + ", maxTrig=" + maxTrig + "]";
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
 	}
 
 }

--- a/src/main/java/rcms/utilities/daqaggregator/data/SubSystem.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/SubSystem.java
@@ -3,7 +3,6 @@ package rcms.utilities.daqaggregator.data;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import rcms.utilities.daqaggregator.mappers.FlashlistType;
@@ -15,7 +14,6 @@ public class SubSystem implements FlashlistUpdatable {
 
 	private String status;
 
-	@JsonManagedReference(value = "subsystem-ttcp")
 	private Set<TTCPartition> ttcPartitions = new HashSet<>();
 
 	public String getName() {
@@ -88,7 +86,7 @@ public class SubSystem implements FlashlistUpdatable {
 		if (ttcPartitions == null) {
 			if (other.ttcPartitions != null)
 				return false;
-		} else if (!ttcPartitions.equals(other.ttcPartitions)){
+		} else if (!ttcPartitions.equals(other.ttcPartitions)) {
 			System.out.println(ttcPartitions);
 			System.out.println(other.ttcPartitions);
 			ttcPartitions.equals(other.ttcPartitions);

--- a/src/main/java/rcms/utilities/daqaggregator/data/TTCPartition.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/TTCPartition.java
@@ -2,12 +2,7 @@ package rcms.utilities.daqaggregator.data;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import rcms.utilities.daqaggregator.mappers.Derivable;
@@ -21,7 +16,6 @@ import rcms.utilities.daqaggregator.mappers.FlashlistUpdatable;
  * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
  */
 
-@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
 public class TTCPartition implements FlashlistUpdatable, Derivable {
 
 	// ----------------------------------------
@@ -33,10 +27,8 @@ public class TTCPartition implements FlashlistUpdatable, Derivable {
 	private boolean masked;
 
 	/** can be null */
-	@JsonBackReference(value = "fmm-ttcp")
 	private FMM fmm;
 
-	@JsonBackReference(value = "subsystem-ttcp")
 	private SubSystem subsystem;
 
 	// ----------------------------------------
@@ -49,7 +41,6 @@ public class TTCPartition implements FlashlistUpdatable, Derivable {
 
 	private float percentBusy;
 
-	@JsonManagedReference(value = "ttcp-fed")
 	private List<FED> feds = new ArrayList<>();
 
 	public String getTtsState() {
@@ -132,7 +123,7 @@ public class TTCPartition implements FlashlistUpdatable, Derivable {
 			String warningKey = "outputFractionWarning";
 			String ttsStateKey = "outputState";
 			String output = "A";
-			if (fmm.takeB)
+			if (fmm.isTakeB())
 				output = "B";
 
 			this.percentBusy = (float) flashlistRow.get(busyKey + output).asDouble() * 100;

--- a/src/main/java/rcms/utilities/daqaggregator/data/mixin/BUMixIn.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/mixin/BUMixIn.java
@@ -1,0 +1,20 @@
+package rcms.utilities.daqaggregator.data.mixin;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
+import rcms.utilities.daqaggregator.data.DAQ;
+
+/**
+ * Class configuring json serialization
+ * 
+ * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
+ *
+ */
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "hostname")
+public interface BUMixIn {
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract DAQ getDaq();
+}

--- a/src/main/java/rcms/utilities/daqaggregator/data/mixin/BUSummaryMixIn.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/mixin/BUSummaryMixIn.java
@@ -1,0 +1,21 @@
+package rcms.utilities.daqaggregator.data.mixin;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
+import rcms.utilities.daqaggregator.data.DAQ;
+
+/**
+ * Class configuring json serialization
+ * 
+ * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
+ *
+ */
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+public interface BUSummaryMixIn {
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract DAQ getDaq();
+
+}

--- a/src/main/java/rcms/utilities/daqaggregator/data/mixin/DAQMixIn.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/mixin/DAQMixIn.java
@@ -1,0 +1,51 @@
+package rcms.utilities.daqaggregator.data.mixin;
+
+import java.util.List;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
+import rcms.utilities.daqaggregator.data.BU;
+import rcms.utilities.daqaggregator.data.BUSummary;
+import rcms.utilities.daqaggregator.data.FEDBuilder;
+import rcms.utilities.daqaggregator.data.FEDBuilderSummary;
+import rcms.utilities.daqaggregator.data.FMMApplication;
+import rcms.utilities.daqaggregator.data.FRLPc;
+import rcms.utilities.daqaggregator.data.SubSystem;
+
+/**
+ * Class configuring json serialization
+ * 
+ * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
+ *
+ */
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+@JsonPropertyOrder({ "sessionId", "runNumber", "lhcMachineMode", "lhcBeamMode", "daqState", "levelZeroState",
+		"dpsetPath", "lastUpdate", "buSummary", "fedBuilderSummary", "subSystems", "ttcPartitions", "bus", "rus",
+		"fmmApplications", "fmms", "fedBuilders", "subFEDBuilders", "frlPcs", "frls", "feds" })
+public interface DAQMixIn {
+
+	// @JsonIdentityReference(alwaysAsId = true)
+	abstract Set<SubSystem> getSubSystems();
+
+	// @JsonIdentityReference(alwaysAsId = true)
+	abstract List<FMMApplication> getFmmApplications();
+
+	// @JsonIdentityReference(alwaysAsId = true)
+	abstract List<FEDBuilder> getFedBuilders();
+
+	// @JsonIdentityReference(alwaysAsId = true)
+	abstract List<FRLPc> getFrlPcs();
+
+	// @JsonIdentityReference(alwaysAsId = true)
+	abstract List<BU> getBus();
+
+	// @JsonIdentityReference(alwaysAsId = true)
+	abstract FEDBuilderSummary getFedBuilderSummary();
+
+	// @JsonIdentityReference(alwaysAsId = true)
+	abstract BUSummary getBuSummary();
+
+}

--- a/src/main/java/rcms/utilities/daqaggregator/data/mixin/FEDBuilderMixIn.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/mixin/FEDBuilderMixIn.java
@@ -1,0 +1,23 @@
+package rcms.utilities.daqaggregator.data.mixin;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
+import rcms.utilities.daqaggregator.data.SubFEDBuilder;
+
+/**
+ * Class configuring json serialization
+ * 
+ * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
+ *
+ */
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "name")
+public interface FEDBuilderMixIn {
+
+	@JsonIdentityReference(alwaysAsId = true)
+	public List<SubFEDBuilder> getSubFedbuilders();
+
+}

--- a/src/main/java/rcms/utilities/daqaggregator/data/mixin/FEDBuilderSummaryMixIn.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/mixin/FEDBuilderSummaryMixIn.java
@@ -1,0 +1,17 @@
+package rcms.utilities.daqaggregator.data.mixin;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
+/**
+ * Class configuring json serialization
+ * 
+ * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
+ *
+ */
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+public interface FEDBuilderSummaryMixIn {
+
+	// nothing to alter
+
+}

--- a/src/main/java/rcms/utilities/daqaggregator/data/mixin/FEDMixIn.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/mixin/FEDMixIn.java
@@ -1,0 +1,29 @@
+package rcms.utilities.daqaggregator.data.mixin;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
+import rcms.utilities.daqaggregator.data.FMM;
+import rcms.utilities.daqaggregator.data.FRL;
+import rcms.utilities.daqaggregator.data.TTCPartition;
+
+/**
+ * Class configuring json serialization
+ * 
+ * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
+ *
+ */
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+public interface FEDMixIn {
+
+	@JsonIdentityReference(alwaysAsId = true)
+	public FRL getFrl();
+
+	@JsonIdentityReference(alwaysAsId = true)
+	public FMM getFmm();
+
+	@JsonIdentityReference(alwaysAsId = true)
+	public TTCPartition getTtcp();
+
+}

--- a/src/main/java/rcms/utilities/daqaggregator/data/mixin/FMMApplicationMixIn.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/mixin/FMMApplicationMixIn.java
@@ -1,0 +1,26 @@
+package rcms.utilities.daqaggregator.data.mixin;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
+import rcms.utilities.daqaggregator.data.DAQ;
+import rcms.utilities.daqaggregator.data.FMM;
+
+/**
+ * Class configuring json serialization
+ * 
+ * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
+ *
+ */
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "hostname")
+public interface FMMApplicationMixIn {
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract DAQ getDaq();
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract List<FMM> getFmms();
+}

--- a/src/main/java/rcms/utilities/daqaggregator/data/mixin/FMMMixIn.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/mixin/FMMMixIn.java
@@ -1,0 +1,35 @@
+package rcms.utilities.daqaggregator.data.mixin;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
+import rcms.utilities.daqaggregator.data.FED;
+import rcms.utilities.daqaggregator.data.FMMApplication;
+import rcms.utilities.daqaggregator.data.TTCPartition;
+
+/**
+ * Class configuring json serialization
+ * 
+ * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
+ *
+ */
+@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id")
+public interface FMMMixIn {
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract TTCPartition getTtcPartition();
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract FMMApplication getFmmApplication();
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract List<FED> getFeds();
+	
+	@JsonIgnore
+	abstract boolean isTakeB();
+
+}

--- a/src/main/java/rcms/utilities/daqaggregator/data/mixin/FRLMixIn.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/mixin/FRLMixIn.java
@@ -1,0 +1,31 @@
+package rcms.utilities.daqaggregator.data.mixin;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
+import rcms.utilities.daqaggregator.data.FED;
+import rcms.utilities.daqaggregator.data.FRLPc;
+import rcms.utilities.daqaggregator.data.SubFEDBuilder;
+
+/**
+ * Class configuring json serialization
+ * 
+ * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
+ *
+ */
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+public interface FRLMixIn {
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract SubFEDBuilder getSubFedbuilder();
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract Map<Integer, FED> getFeds();
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract FRLPc getFrlPc();
+
+}

--- a/src/main/java/rcms/utilities/daqaggregator/data/mixin/FRLPcMixIn.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/mixin/FRLPcMixIn.java
@@ -1,0 +1,22 @@
+package rcms.utilities.daqaggregator.data.mixin;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
+import rcms.utilities.daqaggregator.data.FRL;
+
+/**
+ * Class configuring json serialization
+ * 
+ * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
+ *
+ */
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "hostname")
+public interface FRLPcMixIn {
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract List<FRL> getFrls();
+}

--- a/src/main/java/rcms/utilities/daqaggregator/data/mixin/RUMixIn.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/mixin/RUMixIn.java
@@ -1,0 +1,21 @@
+package rcms.utilities.daqaggregator.data.mixin;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
+import rcms.utilities.daqaggregator.data.FEDBuilder;
+
+/**
+ * Class configuring json serialization
+ * 
+ * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
+ *
+ */
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "hostname")
+public interface RUMixIn {
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract FEDBuilder getFedBuilder();
+
+}

--- a/src/main/java/rcms/utilities/daqaggregator/data/mixin/SubFEDBuilderMixIn.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/mixin/SubFEDBuilderMixIn.java
@@ -1,0 +1,35 @@
+package rcms.utilities.daqaggregator.data.mixin;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
+import rcms.utilities.daqaggregator.data.FEDBuilder;
+import rcms.utilities.daqaggregator.data.FRL;
+import rcms.utilities.daqaggregator.data.FRLPc;
+import rcms.utilities.daqaggregator.data.TTCPartition;
+
+/**
+ * Class configuring json serialization
+ * 
+ * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
+ *
+ */
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+public interface SubFEDBuilderMixIn {
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract FEDBuilder getFedBuilder();
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract TTCPartition getTtcPartition();
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract FRLPc getFrlPc();
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract List<FRL> getFrls();
+
+}

--- a/src/main/java/rcms/utilities/daqaggregator/data/mixin/SubSystemMixIn.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/mixin/SubSystemMixIn.java
@@ -1,0 +1,23 @@
+package rcms.utilities.daqaggregator.data.mixin;
+
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
+import rcms.utilities.daqaggregator.data.TTCPartition;
+
+/**
+ * Class configuring json serialization
+ * 
+ * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
+ *
+ */
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "name")
+public interface SubSystemMixIn {
+
+	@JsonIdentityReference(alwaysAsId = true)
+	Set<TTCPartition> getTtcPartitions();
+
+}

--- a/src/main/java/rcms/utilities/daqaggregator/data/mixin/TTCPartitionMixIn.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/mixin/TTCPartitionMixIn.java
@@ -1,0 +1,31 @@
+package rcms.utilities.daqaggregator.data.mixin;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+
+import rcms.utilities.daqaggregator.data.FED;
+import rcms.utilities.daqaggregator.data.FMM;
+import rcms.utilities.daqaggregator.data.SubSystem;
+
+/**
+ * Class configuring json serialization
+ * 
+ * @author Maciej Gladki (maciej.szymon.gladki@cern.ch)
+ *
+ */
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "name")
+public interface TTCPartitionMixIn {
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract List<FED> getFeds();
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract FMM getFmm();
+
+	@JsonIdentityReference(alwaysAsId = true)
+	abstract SubSystem getSubsystem();
+
+}

--- a/src/main/java/rcms/utilities/daqaggregator/mappers/MappingManager.java
+++ b/src/main/java/rcms/utilities/daqaggregator/mappers/MappingManager.java
@@ -1,7 +1,6 @@
 package rcms.utilities.daqaggregator.mappers;
 
 import java.io.Serializable;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -10,7 +9,6 @@ import java.util.Set;
 import org.apache.log4j.Logger;
 
 import rcms.utilities.daqaggregator.data.DAQ;
-import rcms.utilities.daqaggregator.data.FEDBuilder;
 import rcms.utilities.daqaggregator.data.SubFEDBuilder;
 import rcms.utilities.hwcfg.HardwareConfigurationException;
 import rcms.utilities.hwcfg.dp.DAQPartition;

--- a/src/main/java/rcms/utilities/daqaggregator/mappers/ObjectMapper.java
+++ b/src/main/java/rcms/utilities/daqaggregator/mappers/ObjectMapper.java
@@ -1,5 +1,6 @@
 package rcms.utilities.daqaggregator.mappers;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -135,21 +136,21 @@ public class ObjectMapper {
 		for (rcms.utilities.hwcfg.eq.FMM hwfmm : getHardwareFmms(daqPartition)) {
 			FMM fmm = new FMM();
 			fmm.setGeoslot(hwfmm.getGeoSlot());
-			fmm.setFmmType(FMMType.valueOf( hwfmm.getFMMType().name() ));			
+			fmm.setFmmType(FMMType.valueOf(hwfmm.getFMMType().name()));
 			fmm.setServiceName(hwfmm.getServiceName());
 			if (hwfmm.getDual()) {
 				FMMFMMLink fmmLink = fmmMap.get(hwfmm.getId());
-				if (fmmLink != null &&
-					daqPartition.getDAQPartitionSet().getEquipmentSet().getFMMs().get(fmmLink.getTargetFMMId()).getFMMType().equals( rcms.utilities.hwcfg.eq.FMM.FMMType.pi )) {
+				if (fmmLink != null && daqPartition.getDAQPartitionSet().getEquipmentSet().getFMMs()
+						.get(fmmLink.getTargetFMMId()).getFMMType().equals(rcms.utilities.hwcfg.eq.FMM.FMMType.pi)) {
 					try {
 						int fmmIO = fmmLink.getSourceFMMIO();
 						if (fmmIO == 22 || fmmIO == 23)
-							fmm.takeB = true;
+							fmm.setTakeB(true);
 					} catch (NullPointerException e) {
 						logger.warn("Dual FMM has no link: ");
 						logger.warn("Problem fmm :" + hwfmm.getGeoSlot() + hwfmm.getFMMCrate().getHostName());
 					}
-				} 
+				}
 			}
 			fmms.put(hwfmm.hashCode(), fmm);
 		}
@@ -179,7 +180,13 @@ public class ObjectMapper {
 		FEDBuilderSummary fedBuilderSummary = new FEDBuilderSummary();
 		daq.setFedBuilderSummary(fedBuilderSummary);
 		fedBuilderSummary.setDaq(daq);
-		daq.setAllFeds(new HashSet<FED>(feds.values()));
+
+		daq.setTtcPartitions(new ArrayList<>(ttcpartitionsById.values()));
+		daq.setFmms(new ArrayList<>(fmms.values()));
+		daq.setRus(new ArrayList<>(rus.values()));
+		daq.setFrls(new ArrayList<>(frls.values()));
+		daq.setFeds(new ArrayList<>(feds.values()));
+		daq.setSubFEDBuilders(new ArrayList<>(subFedBuilders.values()));
 
 		logger.info("Retrieval summary " + this.toString());
 		logger.info("Subsystem summary " + subSystems.values());
@@ -197,7 +204,7 @@ public class ObjectMapper {
 
 		int bFmms = 0;
 		for (FMM fmm : fmms.values()) {
-			if (fmm.takeB)
+			if (fmm.isTakeB())
 				bFmms++;
 		}
 

--- a/src/main/java/rcms/utilities/daqaggregator/mappers/RelationMapper.java
+++ b/src/main/java/rcms/utilities/daqaggregator/mappers/RelationMapper.java
@@ -6,13 +6,10 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Vector;
 import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.log4j.Logger;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 import rcms.utilities.daqaggregator.data.DAQ;
 import rcms.utilities.daqaggregator.data.FED;
@@ -74,10 +71,10 @@ public class RelationMapper implements Serializable {
 
 	private void buildRelations() {
 		objectMapper.daq.setBus(new ArrayList<>(objectMapper.bus.values()));
-		objectMapper.daq.setSubSystems(new HashSet<>(objectMapper.subSystems.values()));
+		objectMapper.daq.setSubSystems(new ArrayList<>(objectMapper.subSystems.values()));
 		objectMapper.daq.setFrlPcs(new ArrayList<FRLPc>(objectMapper.frlPcs.values()));
 		objectMapper.daq.setFmmApplications(new ArrayList<FMMApplication>(objectMapper.fmmApplications.values()));
-		objectMapper.daq.getFedBuilders().addAll(objectMapper.fedBuilders.values());
+		objectMapper.daq.setFedBuilders(new ArrayList<>(objectMapper.fedBuilders.values()));
 
 		/* building FMM-FED */
 		int ignoredFeds = 0;

--- a/src/main/java/rcms/utilities/daqaggregator/persistence/PersistorManager.java
+++ b/src/main/java/rcms/utilities/daqaggregator/persistence/PersistorManager.java
@@ -51,10 +51,11 @@ public class PersistorManager {
 			String isoDate = objectMapper.writeValueAsString(new Date(daq.getLastUpdate()));
 
 			StructureSerializer persistor = new StructureSerializer();
-			// persistor.serializeToJSON(daq, isoDate, persistenceDir);
+			String filename = persistor.serializeToJSON(daq, isoDate, persistenceDir);
 			// persistor.serializeToJava(daq, isoDate, persistenceDir);
 			// persistor.serializeToBSON(daq, isoDate, persistenceDir);
-			String filename = persistor.serializeToSmile(daq, isoDate, persistenceDir);
+			// String filename = persistor.serializeToSmile(daq, isoDate,
+			// persistenceDir);
 
 			logger.info("Successfully persisted in " + persistenceDir + " as file " + filename);
 			return filename;
@@ -63,7 +64,6 @@ public class PersistorManager {
 			return null;
 		}
 	}
-
 
 	/**
 	 * Converts files from one format to another

--- a/src/main/java/rcms/utilities/daqaggregator/persistence/StructureSerializer.java
+++ b/src/main/java/rcms/utilities/daqaggregator/persistence/StructureSerializer.java
@@ -13,7 +13,34 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 
+import rcms.utilities.daqaggregator.data.BU;
+import rcms.utilities.daqaggregator.data.BUSummary;
 import rcms.utilities.daqaggregator.data.DAQ;
+import rcms.utilities.daqaggregator.data.FED;
+import rcms.utilities.daqaggregator.data.FEDBuilder;
+import rcms.utilities.daqaggregator.data.FEDBuilderSummary;
+import rcms.utilities.daqaggregator.data.FMM;
+import rcms.utilities.daqaggregator.data.FMMApplication;
+import rcms.utilities.daqaggregator.data.FRL;
+import rcms.utilities.daqaggregator.data.FRLPc;
+import rcms.utilities.daqaggregator.data.RU;
+import rcms.utilities.daqaggregator.data.SubFEDBuilder;
+import rcms.utilities.daqaggregator.data.SubSystem;
+import rcms.utilities.daqaggregator.data.TTCPartition;
+import rcms.utilities.daqaggregator.data.mixin.BUMixIn;
+import rcms.utilities.daqaggregator.data.mixin.BUSummaryMixIn;
+import rcms.utilities.daqaggregator.data.mixin.DAQMixIn;
+import rcms.utilities.daqaggregator.data.mixin.FEDBuilderMixIn;
+import rcms.utilities.daqaggregator.data.mixin.FEDBuilderSummaryMixIn;
+import rcms.utilities.daqaggregator.data.mixin.FEDMixIn;
+import rcms.utilities.daqaggregator.data.mixin.FMMApplicationMixIn;
+import rcms.utilities.daqaggregator.data.mixin.FMMMixIn;
+import rcms.utilities.daqaggregator.data.mixin.FRLMixIn;
+import rcms.utilities.daqaggregator.data.mixin.FRLPcMixIn;
+import rcms.utilities.daqaggregator.data.mixin.RUMixIn;
+import rcms.utilities.daqaggregator.data.mixin.SubFEDBuilderMixIn;
+import rcms.utilities.daqaggregator.data.mixin.SubSystemMixIn;
+import rcms.utilities.daqaggregator.data.mixin.TTCPartitionMixIn;
 
 /**
  * Persists DAQ structure in multiple formats format
@@ -25,19 +52,45 @@ public class StructureSerializer {
 
 	private static final Logger logger = Logger.getLogger(StructureSerializer.class);
 
+	
+	private void addMixins(ObjectMapper objectMapper){
+		objectMapper.addMixIn(BU.class, BUMixIn.class);
+		objectMapper.addMixIn(BUSummary.class, BUSummaryMixIn.class);
+		objectMapper.addMixIn(DAQ.class, DAQMixIn.class);
+		objectMapper.addMixIn(FED.class, FEDMixIn.class);
+		objectMapper.addMixIn(FEDBuilder.class, FEDBuilderMixIn.class);
+		objectMapper.addMixIn(FEDBuilderSummary.class, FEDBuilderSummaryMixIn.class);
+		objectMapper.addMixIn(FMM.class, FMMMixIn.class);
+		objectMapper.addMixIn(FMMApplication.class, FMMApplicationMixIn.class);
+		objectMapper.addMixIn(FRL.class, FRLMixIn.class);
+		objectMapper.addMixIn(FRLPc.class, FRLPcMixIn.class);
+		objectMapper.addMixIn(RU.class, RUMixIn.class);
+		objectMapper.addMixIn(SubFEDBuilder.class, SubFEDBuilderMixIn.class);
+		objectMapper.addMixIn(SubSystem.class, SubSystemMixIn.class);
+		objectMapper.addMixIn(TTCPartition.class, TTCPartitionMixIn.class);
+	}
+
+
 	public String serializeToSmile(DAQ daq, String name, String folder)
 			throws JsonGenerationException, JsonMappingException, IOException {
 		File file = new File(folder + name + ".smile");
-		ObjectMapper mapper = new ObjectMapper(new SmileFactory());
-		mapper.writeValue(file, daq);
+		ObjectMapper objectMapper = new ObjectMapper(new SmileFactory());
+
+		addMixins(objectMapper);
+
+		objectMapper.writeValue(file, daq);
 		return file.getAbsolutePath();
 	}
 
-	public void serializeToJSON(DAQ daq, String name, String folder)
+	public String serializeToJSON(DAQ daqSnapshot, String name, String folder)
 			throws JsonGenerationException, JsonMappingException, IOException {
 		File file = new File(folder + name + ".json");
 		ObjectMapper mapper = new ObjectMapper();
-		mapper.writerWithDefaultPrettyPrinter().writeValue(file, daq);
+
+		addMixins(mapper);
+		mapper.writerWithDefaultPrettyPrinter().writeValue(file, daqSnapshot);
+
+		return file.getAbsolutePath();
 	}
 
 	public DAQ deserializeFromSmile(String filepath) {

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -8,8 +8,8 @@ log4j.appender.FILE=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 
 # Set the name of the file
-log = ${java.io.tmpdir}/aggregator/
-log4j.appender.FILE.File=${log}/log.out
+log = ./logs/
+log4j.appender.FILE.File=${log}/daqagg.out
 
 # Set the immediate flush to true (default)
 log4j.appender.FILE.ImmediateFlush=true


### PR DESCRIPTION
I implemented new persistence policy we discussed. The Jackson persistence configuration is defined in package:
src/main/java/rcms/utilities/daqaggregator/data/mixin/

There is one mixin class for each class from snapshot. For instance:
src/main/java/rcms/utilities/daqaggregator/data/BU.java
src/main/java/rcms/utilities/daqaggregator/data/mixin/BUMixIn.java

We now have separated definitions of snapshot classes and persistence policy - which is good.

There are still few relation mapping bugs - some elements has relations null. Now we should fix known bugs, verify if there is no more problems and work on improvements.
