### PR TITLE
added url to exception message in class LiveAccessServiceExplorer

### DIFF
--- a/src/main/java/rcms/utilities/daqaggregator/datasource/LiveAccessServiceExplorer.java
+++ b/src/main/java/rcms/utilities/daqaggregator/datasource/LiveAccessServiceExplorer.java
@@ -86,7 +86,7 @@ public class LiveAccessServiceExplorer {
 
 		} else {
 			throw new DAQException(DAQExceptionCode.ProblemExploringLAS,
-					"Request to LAS catalog returned with http status: " + a.getLeft());
+					"Request to LAS catalog at " + url + " returned with http status: " + a.getLeft());
 		}
 	}
 


### PR DESCRIPTION
When throwing an exception due to a problem contacting a LAS, the URL of the LAS which was attempted to be contacted is thrown. This makes it easier to find out if an URL is misconfigured or a tunnel is not working etc.
