### PR TITLE
fix for identifying DAQ subsystem session id

### DIFF
--- a/src/main/java/rcms/utilities/daqaggregator/datasource/FlashlistDispatcher.java
+++ b/src/main/java/rcms/utilities/daqaggregator/datasource/FlashlistDispatcher.java
@@ -52,6 +52,29 @@ public class FlashlistDispatcher {
 		this.filter1 = filter1;
 	}
 	
+	/** helper function for dispatch(..): returns the session id (SID) of 
+	 *  the DAQ subsystem or null if not found
+	 */
+	private Integer getDAQsid(Flashlist flashlist) {
+		
+		try {
+			for (JsonNode rowNode : flashlist.getRowsNode()) {
+
+				String subsystemName = rowNode.get("SUBSYS").asText();
+
+				if (subsystemName.equals("DAQ") && rowNode.get("FMURL").asText().contains(filter1)) {
+					return Integer.parseInt(rowNode.get("SID").asText());
+				}
+			} // loop over rows of the flashlist
+		} catch (Exception ex) {
+
+			logger.error("Unexpected exception caught when trying to determine DAQ session id", ex);
+	  }
+
+		// not found or there was a problem
+		return null;
+	}
+	
 	/**
 	 * Dispatch flashlist rows to appropriate objects from DAQ structure. Note
 	 * that a flashlist must be already initialized, for initialization see

--- a/src/main/java/rcms/utilities/daqaggregator/datasource/FlashlistDispatcher.java
+++ b/src/main/java/rcms/utilities/daqaggregator/datasource/FlashlistDispatcher.java
@@ -141,16 +141,25 @@ public class FlashlistDispatcher {
 			dispatchRowsByHostname(flashlist, mappingManager.getObjectMapper().busByHostname, "context");
 			break;
 
-		case LEVEL_ZERO_FM_SUBSYS: // TODO: SID column
-
+		case LEVEL_ZERO_FM_SUBSYS: { 
+		
+			Integer daqSid = this.getDAQsid(flashlist);
+			logger.debug("DAQ session id: " + daqSid);
+			
 			for (JsonNode rowNode : flashlist.getRowsNode()) {
 
-				logger.debug("Current session id: " + mappingManager.getObjectMapper().daq.getSessionId());
+				Integer sid = null;
+				try {
+					sid = Integer.parseInt(rowNode.get("SID").asText());
+				} catch (Exception ex) {
 
-				if (rowNode.get("SID").asText()
-						.contains(String.valueOf(mappingManager.getObjectMapper().daq.getSessionId()))) {
-					logger.debug(
-							"Successfully matched session id: " + mappingManager.getObjectMapper().daq.getSessionId());
+					logger.error("Unexpected exception caught when trying to parse subsystem session id", ex);
+				}
+
+				if (sid != null && daqSid != null && sid.equals(daqSid)) {
+					
+					logger.debug("Successfully matched session id: " + daqSid);
+					
 					String subsystemName = rowNode.get("SUBSYS").asText();
 
 					if (subsystemName.equals("DAQ") && rowNode.get("FMURL").asText().contains(filter1)) {
@@ -166,7 +175,9 @@ public class FlashlistDispatcher {
 				}
 
 			}
-			break;
+		}
+		break;
+		
 		case LEVEL_ZERO_FM_DYNAMIC:
 
 			for (JsonNode rowNode : flashlist.getRowsNode()) {

--- a/src/test/java/rcms/utilities/daqaggregator/datasource/FlashlistDispatcherTest.java
+++ b/src/test/java/rcms/utilities/daqaggregator/datasource/FlashlistDispatcherTest.java
@@ -170,8 +170,6 @@ public class FlashlistDispatcherTest {
 		  String dpsetPath = "/daq2/eq_150929/fb_all_withuTCA/dp_bl116_64BU";
 							
 			Set<String> subsystems = this.getSubsystems(flashlistDir, "topdev", timestamp, dpsetPath);
-
-			System.out.println("subsystems=" + subsystems);
 			
 			testSubsystems(284766, new String[] {
 			  /* "DAQ", "DCS", "DQM", */ "ECAL", "ES", "HCAL", "HF", "PIXEL", "PIXEL_UP",


### PR DESCRIPTION
- now first determining the DAQ session id and only then looping over subsystems, taking only those into account with the same session id as the DAQ subsystem. 
- changed (sub) string comparison to comparing integers after parsing them

Makes test in #79 pass and should therefore fix #44 .
 