### PR TITLE
adding support for recording HLT output bandwidth

### DIFF
--- a/src/main/java/rcms/utilities/daqaggregator/data/DAQ.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/DAQ.java
@@ -67,6 +67,12 @@ public class DAQ implements FlashlistUpdatable {
 	 * HLT stream physics output rate in Hz (events per second)
 	 */
 	private Double hltRate;
+	
+	/**
+	 * HLT output bandwidth (bytes per second)
+	 */
+	private Double hltBandwidth;
+	
 	private String hltKey;
 	private String hltKeyDescription;
 	
@@ -406,6 +412,17 @@ public class DAQ implements FlashlistUpdatable {
 
 	public void setHltRate(Double hltRate) {
 		this.hltRate = hltRate;
+	}
+
+	/** @return the HLT output bandwidth in bytes per second
+	 *  for the Physics stream
+	 */
+	public Double getHltBandwidth()	{
+		return hltBandwidth;
+	}
+
+	public void setHltBandwidth(Double hltBandwidth) {
+		this.hltBandwidth = hltBandwidth;
 	}
 
 	public long getRunStart() {

--- a/src/main/java/rcms/utilities/daqaggregator/data/DAQ.java
+++ b/src/main/java/rcms/utilities/daqaggregator/data/DAQ.java
@@ -64,7 +64,7 @@ public class DAQ implements FlashlistUpdatable {
 	private TCDSGlobalInfo tcdsGlobalInfo;
 	
 	/**
-	 * HLT rate in Hz
+	 * HLT stream physics output rate in Hz (events per second)
 	 */
 	private Double hltRate;
 	private String hltKey;

--- a/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
+++ b/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
@@ -323,7 +323,7 @@ public class F3DataRetriever {
 			Application.initialize("DAQAggregator.properties");
 			ProxyManager.get().startProxy();
 			DiskInfo d = f3dr.getDiskInfo();
-			Double h = f3dr.getHLTInfo(288498);
+			Double h = f3dr.getHLToutputInfo(288498).getEventRate(PHYSICS_STREAM_NAME);
 
 			logger.info(d);
 			logger.info(h);

--- a/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
+++ b/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
@@ -85,6 +85,18 @@ public class F3DataRetriever {
 		}
 	}
 	
+	public HLToutputInfo getHLToutputInfo(int runNumber) throws IOException {
+		HLToutputInfo info = new HLToutputInfo();
+		
+		// fill event rates
+		this.fillHLTInfo(runNumber, info, true);
+
+		// fill bandwidths
+		this.fillHLTInfo(runNumber, info, false);
+		
+		return info;
+	}
+	
 	public Double getHLTInfo(int runNumber) throws IOException {
 		Pair<Integer, List<String>> a = connector.retrieveLines(
 				"http://es-cdaq.cms/sc/php/stream_summary_last.php?setup=cdaq&run=" + runNumber + "&unit=events");

--- a/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
+++ b/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
@@ -10,6 +10,8 @@ import org.apache.log4j.Logger;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
 
 import rcms.utilities.daqaggregator.Application;
 import rcms.utilities.daqaggregator.ProxyManager;
@@ -145,6 +147,41 @@ public class F3DataRetriever {
 
 	}
 
+	/** contains information about the HLT output, retrieved in one go
+	    from the F3 monitoring */
+	public class HLToutputInfo {
+		
+		/** HLT output event rates (events per second) by stream name */
+		private final Map<String, Double> eventRates = new HashMap<String, Double>();
+		
+		/** HLT output bandwidth (bytes per second) by stream name */
+		private final Map<String, Double> bandwidths = new HashMap<String, Double>();
+
+		private void setEventRate(String streamName, double rate) {
+			eventRates.put(streamName, rate);
+		}
+
+		/** @return the event rate (events per second) for the given stream
+		 *  or null if not known
+		 */
+		public Double getEventRate(String streamName) {
+			return eventRates.get(streamName);
+		}
+		
+		private void setBandwidth(String streamName, double bandwidth) {
+			bandwidths.put(streamName, bandwidth);
+		}
+		
+		/** @return the bandwidth (bytes per second) for the given stream
+		 *  or null if not known
+		 */
+		public Double getBandwidth(String streamName) {
+			return bandwidths.get(streamName);
+		}
+		
+	}
+	
+	
 	public void dispatch(DAQ daq) {
 
 		long start = System.currentTimeMillis();

--- a/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
+++ b/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
@@ -274,9 +274,11 @@ public class F3DataRetriever {
 			HLToutputInfo hltInfo = getHLToutputInfo(daq.getRunNumber());
 
 			Double hltOutputRate = hltInfo.getEventRate(PHYSICS_STREAM_NAME);
-
+			Double hltOutputBW   = hltInfo.getBandwidth(PHYSICS_STREAM_NAME);
+			
 			daq.setHltRate(hltOutputRate);
-
+			daq.setHltBandwidth(hltOutputBW);
+			
 			return hltOutputRate != null;
 			
 		} catch (JsonMappingException e) {

--- a/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
+++ b/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
@@ -271,14 +271,14 @@ public class F3DataRetriever {
 	public boolean dispatchHLT(DAQ daq) {
 
 		try {
-			Double d = getHLTInfo(daq.getRunNumber());
-			if (d != null) {
-				daq.setHltRate(d);
-				return true;
-			} else {
-				daq.setHltRate(null);
-			}
+			HLToutputInfo hltInfo = getHLToutputInfo(daq.getRunNumber());
 
+			Double hltOutputRate = hltInfo.getEventRate(PHYSICS_STREAM_NAME);
+
+			daq.setHltRate(hltOutputRate);
+
+			return hltOutputRate != null;
+			
 		} catch (JsonMappingException e) {
 			logger.warn("Could not retrieve F3 HLT rate,  json mapping exception: ", e);
 		} catch (IOException e) {

--- a/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
+++ b/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
@@ -265,6 +265,9 @@ public class F3DataRetriever {
 		}
 	}
 
+	/** @return true if retrieving HLT output information from F3mon
+	 *  was successful, false otherwise
+	 */
 	public boolean dispatchHLT(DAQ daq) {
 
 		try {

--- a/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
+++ b/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
@@ -34,6 +34,8 @@ public class F3DataRetriever {
 		this.connector = connector;
 	}
 
+	public final static String PHYSICS_STREAM_NAME = "Physics";
+	
 	/** @param events if true, fills event rates otherwise fills bandwidths */
 	private void fillHLTInfo(int runNumber, HLToutputInfo hltOutputInfo, boolean events) throws IOException {
 		
@@ -109,7 +111,7 @@ public class F3DataRetriever {
 
 			logger.debug(resultJson);
 			try {
-				return resultJson.elements().next().get("Physics").asDouble();
+				return resultJson.elements().next().get(PHYSICS_STREAM_NAME).asDouble();
 			} catch (NoSuchElementException e) {
 
 				logger.warn("Cannot retrieve hlt rate (no such element) from response: " + result.get(0));

--- a/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
+++ b/src/main/java/rcms/utilities/daqaggregator/datasource/F3DataRetriever.java
@@ -99,35 +99,6 @@ public class F3DataRetriever {
 		return info;
 	}
 	
-	public Double getHLTInfo(int runNumber) throws IOException {
-		Pair<Integer, List<String>> a = connector.retrieveLines(
-				"http://es-cdaq.cms/sc/php/stream_summary_last.php?setup=cdaq&run=" + runNumber + "&unit=events");
-
-		List<String> result = a.getRight();
-
-		long count = result.size();
-		if (count == 1) {
-			JsonNode resultJson = mapper.readValue(result.get(0), JsonNode.class);
-
-			logger.debug(resultJson);
-			try {
-				return resultJson.elements().next().get(PHYSICS_STREAM_NAME).asDouble();
-			} catch (NoSuchElementException e) {
-
-				logger.warn("Cannot retrieve hlt rate (no such element) from response: " + result.get(0));
-				return null;
-			}
-
-			catch (NullPointerException e) {
-				logger.warn("Cannot retrieve hlt rate from response: " + result.get(0));
-				return null;
-			}
-		} else {
-			logger.warn("Expected 1 node as a response but was " + count);
-			return null;
-		}
-	}
-
 	/**
 	 * Gets ramdisk and output disk occupancy levels. It's summary of all cdaq
 	 * BU's

--- a/src/test/java/rcms/utilities/daqaggregator/datasource/F3DataRetrieverTest.java
+++ b/src/test/java/rcms/utilities/daqaggregator/datasource/F3DataRetrieverTest.java
@@ -48,6 +48,14 @@ public class F3DataRetrieverTest {
 		Assert.assertEquals(new Double(71.600171600172d), f3dataRetriever.getHLToutputInfo(0).getEventRate(F3DataRetriever.PHYSICS_STREAM_NAME));
 	}
 
+	@Test
+	public void testHltOutputBandwidth() throws IOException {
+		String fakeResponse = "{\"58\":{\"ALCALUMIPIXELS\":127814.84341484,\"ALCAPHISYM\":0,\"Calibration\":2844043.7580438,\"DQM\":64910.424710425,\"DQMCalibration\":290670.87087087,\"DQMEventDisplay\":0,\"DQMHistograms\":0,\"EcalCalibration\":118622.05062205,\"Error\":0,\"ExpressCosmics\":181467.43886744,\"HLTRates\":41108.193908194,\"L1Rates\":254211.66881167,\"NanoDST\":4938.4384384384,\"Physics\":439103.56070356,\"RPCMON\":0}}";
+		F3DataRetriever f3dataRetriever = new F3DataRetriever(new ConnectorFake(fakeResponse));
+		Assert.assertEquals(new Double(439103.56070356d), f3dataRetriever.getHLToutputInfo(0).getBandwidth(F3DataRetriever.PHYSICS_STREAM_NAME));
+	}
+
+	
 	public class ConnectorFake extends Connector {
 
 		private final String response;

--- a/src/test/java/rcms/utilities/daqaggregator/datasource/F3DataRetrieverTest.java
+++ b/src/test/java/rcms/utilities/daqaggregator/datasource/F3DataRetrieverTest.java
@@ -45,7 +45,7 @@ public class F3DataRetrieverTest {
 	public void testHlt() throws IOException {
 		String fakeResponse = "{\"219\":{\"ALCALUMIPIXELS\":47.190047190047,\"ALCAPHISYM\":0,\"Calibration\":79.365079365079,\"DQM\":6.8640068640069,\"DQMCalibration\":7.9365079365079,\"DQMEventDisplay\":18.618618618619,\"DQMHistograms\":612.44101244101,\"EcalCalibration\":79.365079365079,\"Error\":0,\"ExpressCosmics\":19.004719004719,\"HLTRates\":612.44101244101,\"L1Rates\":612.44101244101,\"NanoDST\":5.7915057915058,\"Physics\":71.600171600172,\"RPCMON\":27.627627627628}}";
 		F3DataRetriever f3dataRetriever = new F3DataRetriever(new ConnectorFake(fakeResponse));
-		Assert.assertEquals(new Double(71.600171600172d), f3dataRetriever.getHLTInfo(0));
+		Assert.assertEquals(new Double(71.600171600172d), f3dataRetriever.getHLToutputInfo(0).getEventRate(F3DataRetriever.PHYSICS_STREAM_NAME));
 	}
 
 	public class ConnectorFake extends Connector {


### PR DESCRIPTION
summary:
- introduced a class `HLToutputInfo` inside class `F3DataRetriever` (similar to class `DiskInfo`) which keeps per stream HLT output event rates and bandwidths. Compared to the earlier code, this now extracts information from all streams which is currently not needed but may be useful in the future.
- added a field `hltBandwidth` to the `DAQ` object, will be required to implement a test for output bandwidth in cmsdaq/DAQExpert#17
- added a test for `hltBandwidth`
- made necessary changes where the modified code needs to used
