### PR TITLE
logging the exception if a .smile file can not be deserialized

### DIFF
--- a/src/main/java/rcms/utilities/daqaggregator/persistence/StructureSerializer.java
+++ b/src/main/java/rcms/utilities/daqaggregator/persistence/StructureSerializer.java
@@ -164,7 +164,7 @@ public class StructureSerializer {
 			daq = mapper.readValue(new File(filepath), DAQ.class);
 			return daq;
 		} catch (IOException i) {
-			logger.error("File incompatible: " + filepath);
+			logger.error("File incompatible: " + filepath, i);
 			i.printStackTrace();
 			return null;
 		} finally {

--- a/src/main/java/rcms/utilities/daqaggregator/persistence/StructureSerializer.java
+++ b/src/main/java/rcms/utilities/daqaggregator/persistence/StructureSerializer.java
@@ -114,8 +114,7 @@ public class StructureSerializer {
 			flashlist = mapper.readValue(file, Flashlist.class);
 			return flashlist;
 		} catch (IOException i) {
-			logger.error("File incompatible: " + file.getAbsolutePath());
-			i.printStackTrace();
+			logger.error("File incompatible: " + file.getAbsolutePath(), i);
 			return null;
 		} finally {
 			if (in != null)

--- a/src/main/java/rcms/utilities/daqaggregator/persistence/StructureSerializer.java
+++ b/src/main/java/rcms/utilities/daqaggregator/persistence/StructureSerializer.java
@@ -165,7 +165,6 @@ public class StructureSerializer {
 			return daq;
 		} catch (IOException i) {
 			logger.error("File incompatible: " + filepath, i);
-			i.printStackTrace();
 			return null;
 		} finally {
 			if (in != null)


### PR DESCRIPTION
added the exception to the call to the logger in class StructureSerializer. This helps to understand why a file can not be deserialized (e.g. unexpected values for a field).
