### PR TITLE
refactoring hardware connector initialize

### DIFF
--- a/src/main/java/rcms/utilities/daqaggregator/DAQAggregator.java
+++ b/src/main/java/rcms/utilities/daqaggregator/DAQAggregator.java
@@ -236,13 +236,7 @@ public class DAQAggregator {
 		 * Setup database
 		 */
 		HardwareConnector hardwareConnector = new HardwareConnector();
-		String url = Application.get().getProp(Settings.HWCFGDB_DBURL);
-		String host = Application.get().getProp(Settings.HWCFGDB_HOST);
-		String port = Application.get().getProp(Settings.HWCFGDB_PORT);
-		String sid = Application.get().getProp(Settings.HWCFGDB_SID);
-		String user = Application.get().getProp(Settings.HWCFGDB_LOGIN);
-		String passwd = Application.get().getProp(Settings.HWCFGDB_PWD);
-		hardwareConnector.initialize(url, host, port, sid, user, passwd);
+		hardwareConnector.initialize(Application.get().getProp());
 
 		/*
 		 * Get persistence dirs

--- a/src/main/java/rcms/utilities/daqaggregator/datasource/HardwareConnector.java
+++ b/src/main/java/rcms/utilities/daqaggregator/datasource/HardwareConnector.java
@@ -1,10 +1,11 @@
 package rcms.utilities.daqaggregator.datasource;
 
+import java.util.Properties;
 import rcms.common.db.DBConnectorException;
 import rcms.common.db.DBConnectorIF;
 import rcms.common.db.DBConnectorMySQL;
 import rcms.common.db.DBConnectorOracle;
-import rcms.utilities.daqaggregator.Application;
+import rcms.utilities.daqaggregator.Settings;
 import rcms.utilities.hwcfg.HWCfgConnector;
 import rcms.utilities.hwcfg.HWCfgDescriptor;
 import rcms.utilities.hwcfg.HardwareConfigurationException;
@@ -38,5 +39,18 @@ public class HardwareConnector {
 			_dbconn = new DBConnectorMySQL(url, user, passwd);
 
 		_hwconn = new HWCfgConnector(_dbconn);
+	}
+
+	public void initialize(Properties prop) throws DBConnectorException,
+					HardwareConfigurationException {
+
+		String url     = prop.getProperty(Settings.HWCFGDB_DBURL.getKey());
+		String host    = prop.getProperty(Settings.HWCFGDB_HOST.getKey());
+		String port    = prop.getProperty(Settings.HWCFGDB_PORT.getKey());
+		String sid     = prop.getProperty(Settings.HWCFGDB_SID.getKey());
+		String user    = prop.getProperty(Settings.HWCFGDB_LOGIN.getKey());
+		String passwd  = prop.getProperty(Settings.HWCFGDB_PWD.getKey());
+
+		initialize(url, host, port, sid, user, passwd);
 	}
 }

--- a/src/test/java/rcms/utilities/daqaggregator/datasource/Compatibility.java
+++ b/src/test/java/rcms/utilities/daqaggregator/datasource/Compatibility.java
@@ -65,13 +65,7 @@ public class Compatibility {
 		flashlistRetriever.prepare(startLimit);
 		SessionRetriever sessionRetriever = new SessionRetriever("toppro", "toppro");
 
-		String url = Application.get().getProp(Settings.HWCFGDB_DBURL);
-		String host = Application.get().getProp(Settings.HWCFGDB_HOST);
-		String port = Application.get().getProp(Settings.HWCFGDB_PORT);
-		String sid = Application.get().getProp(Settings.HWCFGDB_SID);
-		String user = Application.get().getProp(Settings.HWCFGDB_LOGIN);
-		String passwd = Application.get().getProp(Settings.HWCFGDB_PWD);
-		hardwareConnector.initialize(url, host, port, sid, user, passwd);
+		hardwareConnector.initialize(Application.get().getProp());
 		monitorManager = new MonitorManager(flashlistRetriever, sessionRetriever, hardwareConnector);
 	}
 

--- a/src/test/java/rcms/utilities/daqaggregator/datasource/FlashlistDispatcherIT.java
+++ b/src/test/java/rcms/utilities/daqaggregator/datasource/FlashlistDispatcherIT.java
@@ -78,17 +78,11 @@ public class FlashlistDispatcherIT {
 		Properties prop = new Properties();
 		prop.load(new FileInputStream("DAQAggregator.properties"));
 
-		String url = prop.getProperty(Settings.HWCFGDB_DBURL.getKey());
-		String host = prop.getProperty(Settings.HWCFGDB_HOST.getKey());
-		String port = prop.getProperty(Settings.HWCFGDB_PORT.getKey());
-		String sid = prop.getProperty(Settings.HWCFGDB_SID.getKey());
-		String user = prop.getProperty(Settings.HWCFGDB_LOGIN.getKey());
-		String passwd = prop.getProperty(Settings.HWCFGDB_PWD.getKey());
 		String filter1 = prop.getProperty(Settings.SESSION_L0FILTER1.getKey());
 		String filter2 = prop.getProperty(Settings.SESSION_L0FILTER2.getKey());
 
 		// connect to the hardware database
-		hardwareConnector.initialize(url, host, port, sid, user, passwd);
+		hardwareConnector.initialize(prop);
 
 		SessionRetriever sr = new SessionRetriever(filter1, filter2);
 		int sessionId;

--- a/src/test/java/rcms/utilities/daqaggregator/datasource/MonitorManagerTest.java
+++ b/src/test/java/rcms/utilities/daqaggregator/datasource/MonitorManagerTest.java
@@ -55,13 +55,7 @@ public class MonitorManagerTest {
 		HardwareConnector hardwareConnector = new HardwareConnector();
 
 		Application.initialize("DAQAggregator.properties");
-		String url = Application.get().getProp(Settings.HWCFGDB_DBURL);
-		String host = Application.get().getProp(Settings.HWCFGDB_HOST);
-		String port = Application.get().getProp(Settings.HWCFGDB_PORT);
-		String sid = Application.get().getProp(Settings.HWCFGDB_SID);
-		String user = Application.get().getProp(Settings.HWCFGDB_LOGIN);
-		String passwd = Application.get().getProp(Settings.HWCFGDB_PWD);
-		hardwareConnector.initialize(url, host, port, sid, user, passwd);
+		hardwareConnector.initialize(Application.get().getProp());
 		monitorManager = new MonitorManager(flashlistRetriever, sessionRetriever, hardwareConnector);
 	}
 


### PR DESCRIPTION
introduced a method `initialize()` in class HardwareConnector which directly takes an argument of type `Properties` instead of passing login etc. individually.

`mvn integration-test` reports:

`Tests run: 41, Failures: 0, Errors: 0, Skipped: 2`
`Tests run: 6, Failures: 0, Errors: 0, Skipped: 0`
